### PR TITLE
Vulkan version check fix

### DIFF
--- a/shin
+++ b/shin
@@ -9,7 +9,7 @@ configure_dxvk() {
     printf "Vulkan device found. Configuring DXVK...\n" 
 
     # New drivers should support Vulkan 1.3
-    check_recent_ver=$(vulkaninfo --summary | grep apiVersion | grep -o "1\.2")
+    check_recent_ver=$(vulkaninfo --summary | grep apiVersion | grep -o "1\.3")
     if [ "$check_recent_ver" ]; then
         printf "Vulkan 1.3 device detected, using the latest DXVK version...\n"
         version="2.2"

--- a/shin
+++ b/shin
@@ -10,7 +10,7 @@ configure_dxvk() {
 
     # New drivers should support Vulkan 1.3
     check_recent_ver=$(vulkaninfo --summary | grep apiVersion | grep -o "1\.3")
-    if [ "$check_recent_ver" ]; then
+    if ! [ -z "$check_recent_ver" ]; then
         printf "Vulkan 1.3 device detected, using the latest DXVK version...\n"
         version="2.2"
 

--- a/shin
+++ b/shin
@@ -9,7 +9,7 @@ configure_dxvk() {
     printf "Vulkan device found. Configuring DXVK...\n" 
 
     # New drivers should support Vulkan 1.3
-    check_recent_ver=$(vulkaninfo | grep -o "1\.3")
+    check_recent_ver=$(vulkaninfo --summary | grep apiVersion | grep -o "1\.2")
     if [ "$check_recent_ver" ]; then
         printf "Vulkan 1.3 device detected, using the latest DXVK version...\n"
         version="2.2"


### PR DESCRIPTION
The previous code didnt check if a Vulkan layer is an actual layer used by the GPU or not and this cause game to not boot on legacy GPU **with** `vulkan-mesa-layers` or `vulkan-validation-layers` installed.