### PR TITLE
Fix env vars not being used when gamemode runs

### DIFF
--- a/shin
+++ b/shin
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 prefix_addition=""
+game_cmd_prefix=""
 with_dxvk="yes"
 dxvk_version=""
 vkd3d_version="no"
@@ -130,14 +131,14 @@ parse_run_opt() {
     shift; shift
 
     while [ $# -gt 0 ]; do
-        printf "Arguments: $1\n"
+        printf "Argument: $1\n"
 
         case "$1" in
             --nv-glx-offload) prefix_addition="${prefix_addition} __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia";;
             --nv-vk-offload) prefix_addition="${prefix_addition} __NV_PRIME_RENDER_OFFLOAD=1 __VK_LAYER_NV_optimus=NVIDIA_only";;
             --use-zink) prefix_addition="${prefix_addition} __GLX_VENDOR_LIBRARY_NAME=mesa MESA_LOADER_DRIVER_OVERRIDE=zink GALLIUM_DRIVER=zink";;
             --prime-offload) prefix_addition="${prefix_addition} DRI_PRIME=1";;
-            --game-mode) prefix_addition="${prefix_addition} gamemoderun";;
+            --game-mode) prefix_addition="${game_cmd_prefix} gamemoderun";;
 
         esac
 
@@ -148,7 +149,7 @@ parse_run_opt() {
 }
 
 operation_run() {
-    local game_inf game_name game_runner game_dir game_exe game_cmd_prefix previous_dir
+    local game_inf game_name game_runner game_dir game_exe previous_dir
 
     game_inf=$(grep "${1}_" ~/.local/share/shin/mess.vars)
 


### PR DESCRIPTION
Fix a problem where environment variables not being used using the `--game-mode` option when environment variables is present after the `gamemoderun` command.